### PR TITLE
fix: Save coverage reports in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
 
 script:
   - "yarn lint"
-  - "yarn test"
+  - "yarn test --coverage"
   - "yarn codecov"
 
 notifications:

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   "jest": {
     "collectCoverageFrom": [
       "src/**/*.js"
-    ]
+    ],
+    "coverageDirectory": "./coverage"
   }
 }


### PR DESCRIPTION
Fix broken CI badge by ensuring reports are created and uploaded.

Fixes #23.